### PR TITLE
Changes Single/float to Decimal for accurate money calculations

### DIFF
--- a/REWEeBonParserLibrary/Receipt/REWEReceipt.cs
+++ b/REWEeBonParserLibrary/Receipt/REWEReceipt.cs
@@ -27,7 +27,7 @@ namespace REWEeBonParserLibrary
             receiptItems = new List<ReceiptItem>();
         }
 
-        public float TotalAmount { 
+        public Decimal TotalAmount { 
             get { 
                 return receiptItems.Sum(ReceiptItem => ReceiptItem.totalPrice+ReceiptItem.deposit);
             }
@@ -66,13 +66,13 @@ namespace REWEeBonParserLibrary
                             if (previousReceiptItem != null)
                             {
                                 // correct the price
-                                previousReceiptItem.totalPrice = previousReceiptItem.totalPrice + Convert.ToSingle(price);
+                                previousReceiptItem.totalPrice = previousReceiptItem.totalPrice + Convert.ToDecimal(price);
 
                                 continue;
                             }
                         }
 
-                        previousReceiptItem = new ReceiptItem(name, 1, Convert.ToSingle(price));
+                        previousReceiptItem = new ReceiptItem(name, 1, Convert.ToDecimal(price));
                         previousReceiptItem.type = type;
                         receiptItems.Add(previousReceiptItem);
                         // next one!
@@ -95,12 +95,12 @@ namespace REWEeBonParserLibrary
                             {
                                 // if the type is different we actually just let it be a separate item
                                 previousReceiptItem = new ReceiptItem(name, 1, 0);
-                                previousReceiptItem.deposit += Convert.ToSingle(price);
+                                previousReceiptItem.deposit += Convert.ToDecimal(price);
                                 receiptItems.Add(previousReceiptItem);
                             }
                             else
                             {
-                                previousReceiptItem.deposit += Convert.ToSingle(price);
+                                previousReceiptItem.deposit += Convert.ToDecimal(price);
                             }
                         }
                         continue;
@@ -115,8 +115,8 @@ namespace REWEeBonParserLibrary
                         String price = workItem.Remove(0, workItem.LastIndexOf(" ") + 1).Replace(".", "").Replace(",", CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator);
                         String name = workItem.Remove(workItem.LastIndexOf(" "), workItem.Length - workItem.LastIndexOf(" ")).Trim(' ');
 
-                        previousReceiptItem = new ReceiptItem(name, 1, 0.0f);
-                        previousReceiptItem.deposit = Convert.ToSingle(price);
+                        previousReceiptItem = new ReceiptItem(name, 1, 0.0m);
+                        previousReceiptItem.deposit = Convert.ToDecimal(price);
                         receiptItems.Add(previousReceiptItem);
                         continue;
                     }
@@ -131,7 +131,7 @@ namespace REWEeBonParserLibrary
                             if (previousReceiptItem != null)
                             {
                                 // set the last receipt item count
-                                previousReceiptItem.count = Convert.ToSingle(splitted[0]);
+                                previousReceiptItem.count = Convert.ToDecimal(splitted[0]);
                             }
                         }
 
@@ -147,7 +147,7 @@ namespace REWEeBonParserLibrary
                             if (previousReceiptItem != null)
                             {
                                 // set the last receipt item count
-                                previousReceiptItem.count = Convert.ToSingle(splitted[0].Replace(".", "").Replace(",", CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator));
+                                previousReceiptItem.count = Convert.ToDecimal(splitted[0].Replace(".", "").Replace(",", CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator));
                             }
                         }
 

--- a/REWEeBonParserLibrary/Receipt/ReceiptItem.cs
+++ b/REWEeBonParserLibrary/Receipt/ReceiptItem.cs
@@ -15,12 +15,12 @@ namespace REWEeBonParserLibrary
     {
         public char type;
         public String name;
-        public Single count;
-        public Single singlePrice { get { return (totalPrice+deposit)/count; } }
-        public Single totalPrice;
-        public Single deposit;
+        public Decimal count;
+        public Decimal singlePrice { get { return (totalPrice+deposit)/count; } }
+        public Decimal totalPrice;
+        public Decimal deposit;
        
-        public ReceiptItem(string Name, Single Count, float TotalPrice)
+        public ReceiptItem(string Name, Decimal Count, Decimal TotalPrice)
         {
             name = Name;
             count = Count;


### PR DESCRIPTION
I was about to write my own parser, when I searched GH and found yours ;)

One issue I had, was that you used floats everywhere, which resulted in a bunch of incorrect values. I replaced them with the decimal type, so monetary calculations are correct. Not sure if this is wanted by you, but I thought I might as well create this PR as I did the change in my fork anyway.